### PR TITLE
Use `accessList` when sending purchase transactions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,10 @@
+INFURA_URL=
+
+TESTNET_PRIVATE_KEY=
+
+# Because of EIP 2929 we must provide an access list for transactions
+# that transfer ETH to a Gnosis safe, and that list must include the
+# implementation contract (or master copy) address for that safe.
+# https://help.gnosis-safe.io/en/articles/5249851-why-can-t-i-transfer-eth-from-a-contract-into-a-safe
+# https://ethereum.stackexchange.com/questions/122347/transferring-eth-from-contract-to-safe
+SELLER_WALLET_IMPL=

--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -1,0 +1,19 @@
+name: Notify CPT
+on:
+  pull_request:
+    types: [opened, reopened]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: send telegram message on push
+        uses: appleboy/telegram-action@master
+        with:
+          to: ${{ secrets.TELEGRAM_TO }}
+          token: ${{ secrets.TELEGRAM_TOKEN }}
+          message: |
+            ${{ github.actor }} opened a PR for review:
+
+            ${{ github.event.pull_request.title }}  
+            ${{ github.event.pull_request._links.html.href }}

--- a/src/contracts/index.ts
+++ b/src/contracts/index.ts
@@ -2,6 +2,8 @@ import { ethers } from "ethers";
 
 import { WolfSale, WolfSale__factory } from "./types";
 
+export * from "./types"
+
 export const getWolfSaleContract = async (
   provider: ethers.providers.Provider | ethers.Signer,
   address: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import * as ethers from "ethers";
+import { WolfSale } from "./contracts";
 
 export type Maybe<T> = T | undefined | null;
 
@@ -157,7 +158,8 @@ export interface Instance {
   purchaseDomains(
     count: ethers.BigNumber,
     signer: ethers.Signer,
-    saleToken?: string
+    contract: WolfSale,
+    mintlist: Mintlist
   ): Promise<ethers.ContractTransaction>;
 
   /** Admin helper to pause the sale */

--- a/test/actions.test.ts
+++ b/test/actions.test.ts
@@ -2,68 +2,109 @@ import * as chai from "chai";
 import * as chaiAsPromised from "chai-as-promised"
 import * as dotenv from "dotenv";
 import { ethers } from "ethers";
+import { createInstance } from "../src";
 
 import * as actions from "../src/actions";
-import { getSaleStatus, getWhitelist } from "../src/actions";
-import { getWhiteListSaleContract } from "../src/contracts";
-import { Claim, IPFSGatewayUri, SaleStatus } from "../src/types";
+import { getSaleStatus, getMintlist } from "../src/actions";
+import { getWolfSaleContract, WolfSale } from "../src/contracts";
+import { Claim, Config, Instance, Maybe, Mintlist, SaleStatus } from "../src/types";
 
 const expect = chai.expect;
 chai.use(chaiAsPromised.default);
 dotenv.config();
 
 describe("Test Custom SDK Logic", () => {
-  // Kovan
-  const whitelistSimpleSaleContractAddress =
-    "0xa6A3321b743C31912263090275E24d8b1A50cFE8";
   const provider = new ethers.providers.JsonRpcProvider(
-    process.env["INFURA_URL"]
+    process.env["INFURA_URL"],
+    4
   );
-  const pk = process.env["PRIVATE_KEY"];
+
+  const pk = process.env["ASTRO_PRIVATE_KEY"];
   if (!pk) throw Error("No private key");
 
   const signer = new ethers.Wallet(pk, provider);
 
   const voidSignerAddress = "0x8ba1f109551bD432803012645Ac136ddd64DBA72";
-  const addressFromFile = "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65";
+  const astroTest = "0x35888AD3f1C0b39244Bb54746B96Ee84A5d97a53";
 
   // Sample merkle file
   const ipfsUrl =
     "ipfs://bafybeihy6gypowkcfwtsuvspbqah6chvtfjd3lz5xcjdvwnwyjdxh2bufa";
 
-  describe("getWhitelistedUserClaim", () => {
+  // From dApp Rinkeby zSale SDK Config
+  const config: Config = {
+    web3Provider: provider,
+    contractAddress: "0xC82E9E9B1e28F10a4C13a915a0BDCD4Db00d086d",
+    // Using Rinkeby not Kovan, but can use same file for tests
+    merkleTreeFileUri: 'https://d3810nvssqir6b.cloudfront.net/kovan-test-merkleTree.json',
+    advanced: {
+      merkleTreeFileIPFSHash:
+        'Qmf8XuYT181zdvhNXSeYUhkptgezzK8QJnrAD16GGj8TrV',
+    },
+  }
+
+  describe("e2e purchase", () => {
+    it("runs with access list", async () => {
+      const sdk: Instance = createInstance(config);
+      const mintlist = await sdk.getMintlist()
+
+      const wolfSale = await getWolfSaleContract(signer, config.contractAddress)
+      const address = await signer.getAddress()
+
+      const args = {
+        count: ethers.BigNumber.from("1"),
+        signer: signer,
+        contract: wolfSale,
+        mintlist: mintlist
+      }
+
+      const claim = mintlist.claims[address];
+
+      const purchased = await wolfSale.domainsPurchasedByAccount(address)
+
+      const tx = await sdk.purchaseDomains(
+        args.count,
+        args.signer,
+        args.contract,
+        args.mintlist
+      );
+
+      const receipt = await tx.wait(1);
+    })
+  })
+  describe("getMintlistedUserClaim", () => {
     it("errors when address is not in merkle tree", async () => {
-      const whitelist = await getWhitelist(ipfsUrl, IPFSGatewayUri.fleek, undefined);
-      const userClaim: Claim = whitelist.claims[voidSignerAddress];
+      const mintlist = await getMintlist(config);
+      const userClaim: Maybe<Claim> = mintlist.claims[voidSignerAddress];
       expect(userClaim).to.equal(undefined);
     });
     it("returns the account information when address is in the merkle tree", async () => {
-      const whitelist = await getWhitelist(ipfsUrl, IPFSGatewayUri.fleek, undefined);
-      const userClaim: Claim = whitelist.claims[addressFromFile];
+      const mintlist = await getMintlist(config);
+      const userClaim: Maybe<Claim> = mintlist.claims[astroTest];
       expect(userClaim);
     });
   });
   describe("getSaleStatus", () => {
     it("runs", async () => {
-      const contract = await getWhiteListSaleContract(
+      const contract = await getWolfSaleContract(
         signer,
-        whitelistSimpleSaleContractAddress
+        config.contractAddress
       );
       const status = await getSaleStatus(contract);
-      expect(status).to.equal(SaleStatus.Public);
+      expect(status).to.equal(SaleStatus.PublicSale);
     });
   });
-  describe("getWhitelist", () => {
+  describe("getMintlist", () => {
     it("runs", async () => {
-      const whitelist = await getWhitelist(ipfsUrl, IPFSGatewayUri.fleek, undefined);
+      const whitelist = await getMintlist(config);
       expect(whitelist);
     });
   });
   describe("getSaleData", () => {
     it("runs", async () => {
-      const contract = await getWhiteListSaleContract(
+      const contract = await getWolfSaleContract(
         signer,
-        whitelistSimpleSaleContractAddress
+        config.contractAddress
       );
       const data = await actions.getSaleData(contract, true);
       expect(data);


### PR DESCRIPTION
The use of the `accessList` override allows us to specify a Gnosis safe as the seller wallet in sales. Without the `accessList`, EIP 2929 causes payments to fail for Gnosis safes unless explicitly defined this way.

[Read more.](https://help.gnosis-safe.io/en/articles/5249851-why-can-t-i-transfer-eth-from-a-contract-into-a-safe)