### PR TITLE
 MetaMask - RPC Error: Invalid transaction envelope type: specified t…

### DIFF
--- a/src/actions/purchaseDomains.ts
+++ b/src/actions/purchaseDomains.ts
@@ -113,7 +113,7 @@ export const purchaseDomains = async (
       userClaim.proof,
       {
         value: price.mul(count),
-        type: 1,
+        type: 2,
         accessList: accessList,
       }
     );


### PR DESCRIPTION
…ype 0x1 but including maxFeePerGas and maxPriorityFeePerGas requires type: 0x2