### PR TITLE
Adjust number purchasable by account

### DIFF
--- a/src/actions/genSale/getMintlist.ts
+++ b/src/actions/genSale/getMintlist.ts
@@ -2,60 +2,60 @@ import { fetch } from "cross-fetch";
 import { Maybe, Mintlist, GenSaleConfig } from "../../types";
 
 const extractIPFSHash = (hay: string) => {
-    const regex = /(Qm.+)$/;
-    const matches = regex.exec(hay);
-    if (!matches) {
-        return undefined;
-    }
-    return matches[1];
+	const regex = /(Qm.+)$/;
+	const matches = regex.exec(hay);
+	if (!matches) {
+		return undefined;
+	}
+	return matches[1];
 };
 
 const defaultIpfsGateway = "https://ipfs.io/ipfs/";
 
 export const getMintlist = async (config: GenSaleConfig) => {
-    let mintlist: Maybe<Mintlist>;
+	let mintlist: Maybe<Mintlist>;
 
-    // fetch via main uri
-    try {
-        const res = await fetch(config.merkleTreeFileUri, {
-            method: "GET",
-        });
-        mintlist = (await res.json()) as Mintlist;
-        return mintlist;
-    } catch (e) {
-        console.error(
-            `Unable to fetch mint list via uri ${config.merkleTreeFileUri}`
-        );
-    }
+	// fetch via main uri
+	try {
+		const res = await fetch(config.merkleTreeFileUri, {
+			method: "GET",
+		});
+		mintlist = (await res.json()) as Mintlist;
+		return mintlist;
+	} catch (e) {
+		console.error(
+			`Unable to fetch mint list via uri ${config.merkleTreeFileUri}`
+		);
+	}
 
-    let ipfsHash: Maybe<string>;
-    if (config.advanced?.merkleTreeFileIPFSHash) {
-        ipfsHash = config.advanced.merkleTreeFileIPFSHash;
-        if (!ipfsHash) {
-            ipfsHash = extractIPFSHash(config.merkleTreeFileUri);
-        }
-    }
+	let ipfsHash: Maybe<string>;
+	if (config.advanced?.merkleTreeFileIPFSHash) {
+		ipfsHash = config.advanced.merkleTreeFileIPFSHash;
+		if (!ipfsHash) {
+			ipfsHash = extractIPFSHash(config.merkleTreeFileUri);
+		}
+	}
 
-    // need an IPFS hash or we cant get via ipfs
-    if (!ipfsHash) {
-        console.error(`No IPFS Hash to fallback on.`);
-        throw Error(`Unable to fetch mintlist via url.`);
-    }
+	// need an IPFS hash or we cant get via ipfs
+	if (!ipfsHash) {
+		console.error(`No IPFS Hash to fallback on.`);
+		throw Error(`Unable to fetch mintlist via url.`);
+	}
 
-    let ipfsGateway = config.advanced?.ipfsGateway ?? defaultIpfsGateway;
-    if (ipfsGateway[ipfsGateway.length - 1] !== "/") {
-        // check if user forgot to add a / at the end of the gateway
-        ipfsGateway += "/";
-    }
+	let ipfsGateway = config.advanced?.ipfsGateway ?? defaultIpfsGateway;
+	if (ipfsGateway[ipfsGateway.length - 1] !== "/") {
+		// check if user forgot to add a / at the end of the gateway
+		ipfsGateway += "/";
+	}
 
-    // fetch via ipfs
-    try {
-        const ipfsUri = `${ipfsGateway}${ipfsHash}`;
-        const res = await fetch(ipfsUri, { method: "GET" });
-        mintlist = (await res.json()) as Mintlist;
-        return mintlist;
-    } catch (e) {
-        console.error(e);
-        throw Error(`Unable to fetch mintlist via IPFS.`);
-    }
+	// fetch via ipfs
+	try {
+		const ipfsUri = `${ipfsGateway}${ipfsHash}`;
+		const res = await fetch(ipfsUri, { method: "GET" });
+		mintlist = (await res.json()) as Mintlist;
+		return mintlist;
+	} catch (e) {
+		console.error(e);
+		throw Error(`Unable to fetch mintlist via IPFS.`);
+	}
 };

--- a/src/actions/genSale/getSaleData.ts
+++ b/src/actions/genSale/getSaleData.ts
@@ -4,26 +4,26 @@ import { GenSaleData } from "../../types";
 import { getSaleStatus } from "./getSaleStatus";
 
 export const getSaleData = async (
-    contract: GenSale
+  contract: GenSale
 ): Promise<GenSaleData> => {
-    const started = await contract.saleStarted();
+  const started = await contract.saleStarted();
 
-    const startBlock = started
-        ? (await contract.saleStartBlock()).toNumber()
-        : undefined;
+  const startBlock = started
+    ? (await contract.saleStartBlock()).toNumber()
+    : undefined;
 
-    const amountForSale = (await contract.amountForSale()).toNumber();
-    const limitPerTransaction = (await contract.limitPerTransaction()).toNumber();
+  const amountForSale = (await contract.amountForSale()).toNumber();
+  const limitPerTransaction = (await contract.limitPerTransaction()).toNumber();
 
-    const saleData: GenSaleData = {
-        amountSold: (await contract.domainsSold()).toNumber(),
-        amountForSale: amountForSale,
-        salePrice: ethers.utils.formatEther(await contract.salePrice()),
-        started: started,
-        paused: await contract.paused(),
-        startBlock: startBlock,
-        limitPerTransaction: limitPerTransaction,
-        saleStatus: await getSaleStatus(contract)
-    };
-    return saleData;
+  const saleData: GenSaleData = {
+    amountSold: (await contract.domainsSold()).toNumber(),
+    amountForSale: amountForSale,
+    salePrice: ethers.utils.formatEther(await contract.salePrice()),
+    started: started,
+    paused: await contract.paused(),
+    startBlock: startBlock,
+    limitPerTransaction: limitPerTransaction,
+    saleStatus: await getSaleStatus(contract)
+  };
+  return saleData;
 };

--- a/src/actions/genSale/getSaleStatus.ts
+++ b/src/actions/genSale/getSaleStatus.ts
@@ -3,32 +3,32 @@ import { GenSale } from "../../contracts/types";
 import { GenSaleStatus } from "../../types";
 
 export const getSaleStatus = async (contract: GenSale) => {
-    const saleStarted = await contract.saleStarted();
+  const saleStarted = await contract.saleStarted();
 
-    if (!saleStarted) {
-        return GenSaleStatus.NotStarted;
+  if (!saleStarted) {
+    return GenSaleStatus.NotStarted;
+  }
+
+  const saleDataPromises = [
+    contract.domainsSold(),
+    contract.amountForSale(),
+    contract.salePrice(),
+  ];
+
+  const [
+    numSold,
+    totalForSale,
+    price
+  ] = await Promise.all(saleDataPromises)
+
+  if (numSold.gte(totalForSale)) {
+    return GenSaleStatus.Ended;
+  }
+
+  if (price.gt(0)) {
+    if (saleStarted) {
+      return GenSaleStatus.PrivateSale;
     }
-
-    const saleDataPromises = [
-        contract.domainsSold(),
-        contract.amountForSale(),
-        contract.salePrice(),
-    ];
-
-    const [
-        numSold,
-        totalForSale,
-        price
-    ] = await Promise.all(saleDataPromises)
-
-    if (numSold.gte(totalForSale)) {
-        return GenSaleStatus.Ended;
-    }
-
-    if (price.gt(0)) {
-        if (saleStarted) {
-            return GenSaleStatus.PrivateSale;
-        }
-    }
-    return GenSaleStatus.ClaimSale;
+  }
+  return GenSaleStatus.ClaimSale;
 };

--- a/src/actions/genSale/purchaseDomains.ts
+++ b/src/actions/genSale/purchaseDomains.ts
@@ -5,77 +5,77 @@ import { errorCheck } from "../../helpers";
 import { Claim, Mintlist, Maybe, GenSaleStatus } from "../../types";
 
 export const purchaseDomains = async (
-    count: ethers.BigNumber,
-    signer: ethers.Signer,
-    contract: GenSale,
-    mintlist: Mintlist
+  count: ethers.BigNumber,
+  signer: ethers.Signer,
+  contract: GenSale,
+  mintlist: Mintlist
 ): Promise<ethers.ContractTransaction> => {
-    const status: GenSaleStatus = await getSaleStatus(contract);
+  const status: GenSaleStatus = await getSaleStatus(contract);
 
+  errorCheck(
+    status === GenSaleStatus.NotStarted,
+    "Cannot purchase a domain when sale has not started"
+  );
+
+  errorCheck(status === GenSaleStatus.Ended, "Sale has already ended");
+
+  errorCheck(count.eq("0"), "Cannot purchase 0 domains");
+
+  const paused = await contract.paused();
+  errorCheck(paused, "Sale contract is paused");
+
+  const address = await signer.getAddress();
+  const balance = await signer.getBalance();
+  const price = await contract.salePrice();
+
+  errorCheck(
+    balance.lt(price.mul(count)),
+    `Not enough funds given for purchase of ${count} domains`
+  );
+
+  let tx: ethers.ContractTransaction;
+  const purchased = await contract.domainsPurchasedByAccount(address);
+  let userClaim: Maybe<Claim> = mintlist.claims[address];
+
+  // To purchase in private sale a user must be on the mintlist
+  errorCheck(!userClaim, "User is not part of claim sale");
+  userClaim = userClaim!;
+
+  if (status === GenSaleStatus.ClaimSale) {  //Claim Sale, not yet private sale
+
+    // Cannot purchase over the allowed mintlist limit
     errorCheck(
-        status === GenSaleStatus.NotStarted,
-        "Cannot purchase a domain when sale has not started"
+      purchased.add(count).gt(userClaim.quantity),
+      `This user has already claimed ${purchased.toString()} and claiming ${count.toString()} more domains would go over the maximum claim amount of domains for this user, ${userClaim.quantity}. Try reducing the claim amount.`
     );
 
-    errorCheck(status === GenSaleStatus.Ended, "Sale has already ended");
-
-    errorCheck(count.eq("0"), "Cannot purchase 0 domains");
-
-    const paused = await contract.paused();
-    errorCheck(paused, "Sale contract is paused");
-
-    const address = await signer.getAddress();
-    const balance = await signer.getBalance();
-    const price = await contract.salePrice();
-
+    tx = await contract
+      .connect(signer)
+      .purchaseDomains(
+        count,
+        userClaim.index,
+        userClaim.quantity,
+        userClaim.proof
+      );
+  } else {
+    // Private sale
+    const transactionLimit = await contract.limitPerTransaction();
     errorCheck(
-        balance.lt(price.mul(count)),
-        `Not enough funds given for purchase of ${count} domains`
+      count.gt(transactionLimit),
+      `The given number of ${count.toString()} exceeds the purchase limit per transaction in the Private Sale: ${transactionLimit.toString()}.`
     );
 
-    let tx: ethers.ContractTransaction;
-    const purchased = await contract.domainsPurchasedByAccount(address);
-    let userClaim: Maybe<Claim> = mintlist.claims[address];
-
-    // To purchase in private sale a user must be on the mintlist
-    errorCheck(!userClaim, "User is not part of claim sale");
-    userClaim = userClaim!;
-
-    if (status === GenSaleStatus.ClaimSale) {  //Claim Sale, not yet private sale
-
-        // Cannot purchase over the allowed mintlist limit
-        errorCheck(
-            purchased.add(count).gt(userClaim.quantity),
-            `This user has already claimed ${purchased.toString()} and claiming ${count.toString()} more domains would go over the maximum claim amount of domains for this user, ${userClaim.quantity}. Try reducing the claim amount.`
-        );
-
-        tx = await contract
-            .connect(signer)
-            .purchaseDomains(
-                count,
-                userClaim.index,
-                userClaim.quantity,
-                userClaim.proof
-            );
-    } else {
-        // Private sale
-        const transactionLimit = await contract.limitPerTransaction();
-        errorCheck(
-            count.gt(transactionLimit),
-            `The given number of ${count.toString()} exceeds the purchase limit per transaction in the Private Sale: ${transactionLimit.toString()}.`
-        );
-
-        tx = await contract
-            .connect(signer)
-            .purchaseDomains(
-                count,
-                userClaim.index,
-                userClaim.quantity,
-                userClaim.proof,
-                {
-                    value: price.mul(count)
-                }
-            );
-    }
-    return tx;
+    tx = await contract
+      .connect(signer)
+      .purchaseDomains(
+        count,
+        userClaim.index,
+        userClaim.quantity,
+        userClaim.proof,
+        {
+          value: price.mul(count)
+        }
+      );
+  }
+  return tx;
 };

--- a/src/actions/genSale/setPauseStatus.ts
+++ b/src/actions/genSale/setPauseStatus.ts
@@ -2,15 +2,15 @@ import { ethers } from "ethers";
 import { GenSale } from "../../contracts/types";
 
 export const setPauseStatus = async (
-    pauseStatus: boolean,
-    saleContract: GenSale,
-    signer: ethers.Signer
+  pauseStatus: boolean,
+  saleContract: GenSale,
+  signer: ethers.Signer
 ): Promise<ethers.ContractTransaction> => {
-    const currentStatus = await saleContract.paused();
-    if (pauseStatus === currentStatus) {
-        throw Error("Execution would cause no state change");
-    }
+  const currentStatus = await saleContract.paused();
+  if (pauseStatus === currentStatus) {
+    throw Error("Execution would cause no state change");
+  }
 
-    const tx = await saleContract.connect(signer).setPauseStatus(pauseStatus);
-    return tx;
+  const tx = await saleContract.connect(signer).setPauseStatus(pauseStatus);
+  return tx;
 };


### PR DESCRIPTION
 - Adjust the `numberPurchasableByAccount` function to return the difference between the amount that user can buy and they amount they already have bought.
 - Move some `await` functions to only be called when we are certain we require them
 - Format file indentation for consistency with rest of codebase 